### PR TITLE
add spot fleet request role 

### DIFF
--- a/aws/eks/master/outputs.tf
+++ b/aws/eks/master/outputs.tf
@@ -21,3 +21,7 @@ output "worker_sg_id" {
 output "s3_bucket" {
   value = "${aws_s3_bucket.vishwakarma.bucket}"
 }
+
+output "spot_fleet_role_arn" {
+  value = "${aws_iam_role.spot_fleet.arn}"
+}

--- a/aws/eks/master/role.tf
+++ b/aws/eks/master/role.tf
@@ -1,3 +1,4 @@
+# Role for EKS Cluster
 data "aws_iam_policy_document" "cluster_assume_role_policy" {
   statement {
     sid = "EKSClusterAssumeRole"
@@ -26,4 +27,30 @@ resource "aws_iam_role_policy_attachment" "eks_cluster" {
 resource "aws_iam_role_policy_attachment" "eks_service" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
   role       = "${aws_iam_role.eks.name}"
+}
+
+# Role for Spot Fleet
+resource "aws_iam_role" "spot_fleet" {
+  name = "${var.phase}-${var.project}-fleet-role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "spotfleet.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "spot_fleet" {
+  role       = "${aws_iam_role.spot_fleet.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole"
 }

--- a/aws/eks/worker-spot/spot.tf
+++ b/aws/eks/worker-spot/spot.tf
@@ -1,6 +1,6 @@
 resource "aws_spot_fleet_request" "workers" {
   count                               = "${var.aws_az_number}"
-  iam_fleet_role                      = "${data.aws_iam_role.spot_fleet.arn}"
+  iam_fleet_role                      = "${var.spot_fleet_role}"
   load_balancers                      = "${var.load_balancers}"
   target_group_arns                   = "${var.target_group_arns}"
   spot_price                          = "0.1"
@@ -69,8 +69,4 @@ resource "aws_spot_fleet_request" "workers" {
   depends_on = [
     "module.worker_common"
   ]
-}
-
-data "aws_iam_role" "spot_fleet" {
-  name = "AWSServiceRoleForEC2SpotFleet"
 }

--- a/aws/eks/worker-spot/variables.tf
+++ b/aws/eks/worker-spot/variables.tf
@@ -170,3 +170,9 @@ variable "worker_iam_role" {
 variable "s3_bucket" {
   type = "string"
 }
+
+variable "spot_fleet_role" {
+  type        = "string"
+  default     = ""
+  description = "Spot fleet role for spot fleet request spot instance"
+}

--- a/examples/eks_worker/main.tf
+++ b/examples/eks_worker/main.tf
@@ -63,6 +63,7 @@ module "workers_spot" {
   instance_count                       = "${var.worker_spot["instance_count"]}"
   root_volume_size                     = "${var.worker_spot["root_volume_size"]}"
   root_volume_type                     = "${var.worker_spot["root_volume_type"]}"
+  spot_fleet_role                      = "${module.master.spot_fleet_role_arn}"
   sg_ids                               = ["${module.master.worker_sg_id}"]
   s3_bucket                            = "${module.master.s3_bucket}"
   ssh_key                              = "${var.key_pair_name}"


### PR DESCRIPTION
Adding the spot fleet request role into EKS cluster module,
due to if adding it into spot worker node module, 
during destroy process, Terraform will delete it before spot instance terminated,
That causes destroy fail