### PR TITLE
rename version variable to kubernetes_version

### DIFF
--- a/aws/elastikube/ign-essential.tf
+++ b/aws/elastikube/ign-essential.tf
@@ -10,7 +10,7 @@ module "ignition_kube_addon_manager" {
 
   hyperkube = {
     image_path = "gcr.io/google-containers/hyperkube-amd64"
-    image_tag  = "${var.version}"
+    image_tag  = "${var.kubernetes_version}"
   }
 }
 
@@ -36,7 +36,7 @@ module "ignition_kube_addon_proxy" {
 
   hyperkube = {
     image_path = "gcr.io/google-containers/hyperkube-amd64"
-    image_tag  = "${var.version}"
+    image_tag  = "${var.kubernetes_version}"
   }
 }
 

--- a/aws/elastikube/master.tf
+++ b/aws/elastikube/master.tf
@@ -7,7 +7,7 @@ module "master" {
   ssh_key       = "${var.ssh_key}"
   master_config = "${var.master_config}"
   role_name     = "${var.role_name}"
-  version       = "${var.version}"
+  version       = "${var.kubernetes_version}"
 
   security_group_ids = [
     "${var.security_group_ids}"

--- a/aws/elastikube/outputs.tf
+++ b/aws/elastikube/outputs.tf
@@ -11,7 +11,7 @@ output "endpoint" {
 }
 
 output "version" {
-  value = "${var.version}"
+  value = "${var.kubernetes_version}"
 }
 
 output "vpc_id" {

--- a/aws/elastikube/variables.tf
+++ b/aws/elastikube/variables.tf
@@ -44,7 +44,7 @@ variable "subnet_ids" {
 EOF
 }
 
-variable "version" {
+variable "kubernetes_version" {
   type        = "string"
   default     = "v1.13.1"
   description = "(Optional) Desired Kubernetes master version. If you do not specify a value, the latest available version is used."

--- a/aws/kube-master/ign-control-plane.tf
+++ b/aws/kube-master/ign-control-plane.tf
@@ -50,6 +50,6 @@ module "ignition_kube_control_plane" {
 
   hyperkube = {
     image_path = "gcr.io/google-containers/hyperkube-amd64"
-    image_tag  = "${var.version}"
+    image_tag  = "${var.kubernetes_version}"
   }
 }

--- a/aws/kube-master/ign-kubelet.tf
+++ b/aws/kube-master/ign-kubelet.tf
@@ -29,6 +29,6 @@ module "ignition_kubelet" {
 
   hyperkube = {
     image_path = "gcr.io/google-containers/hyperkube-amd64"
-    image_tag  = "${var.version}"
+    image_tag  = "${var.kubernetes_version}"
   }
 }

--- a/aws/kube-master/variables.tf
+++ b/aws/kube-master/variables.tf
@@ -55,7 +55,7 @@ variable "subnet_ids" {
 EOF
 }
 
-variable "version" {
+variable "kubernetes_version" {
   type        = "string"
   default     = "v1.13.1"
   description = "(Optional) Desired Kubernetes master version. If you do not specify a value, the latest available version is used."

--- a/aws/kube-worker-general/ignition.tf
+++ b/aws/kube-worker-general/ignition.tf
@@ -41,7 +41,7 @@ module "ignition_kubelet" {
 
   hyperkube = {
     image_path = "gcr.io/google-containers/hyperkube-amd64"
-    image_tag  = "${var.version}"
+    image_tag  = "${var.kubernetes_version}"
   }
 }
 

--- a/aws/kube-worker-general/variables.tf
+++ b/aws/kube-worker-general/variables.tf
@@ -36,7 +36,7 @@ variable "subnet_ids" {
 EOF
 }
 
-variable "version" {
+variable "kubernetes_version" {
   type        = "string"
   default     = "v1.13.1"
   description = "(Optional) Desired Kubernetes kubelet version. If you do not specify a value, the latest available version is used."

--- a/aws/kube-worker-mixed/ignition.tf
+++ b/aws/kube-worker-mixed/ignition.tf
@@ -41,7 +41,7 @@ module "ignition_kubelet" {
 
   hyperkube = {
     image_path = "gcr.io/google-containers/hyperkube-amd64"
-    image_tag  = "${var.version}"
+    image_tag  = "${var.kubernetes_version}"
   }
 }
 

--- a/aws/kube-worker-mixed/variables.tf
+++ b/aws/kube-worker-mixed/variables.tf
@@ -36,7 +36,7 @@ variable "subnet_ids" {
 EOF
 }
 
-variable "version" {
+variable "kubernetes_version" {
   type        = "string"
   default     = "v1.13.1"
   description = "(Optional) Desired Kubernetes kubelet version. If you do not specify a value, the latest available version is used."

--- a/examples/aws-iam-authenticator/main.tf
+++ b/examples/aws-iam-authenticator/main.tf
@@ -39,11 +39,11 @@ module "network" {
 module "kubernetes" {
   source = "../../aws/elastikube"
 
-  name         = "${local.cluster_name}"
-  aws_region   = "${var.aws_region}"
-  version      = "${local.kubernetes_version}"
-  service_cidr = "${var.service_cidr}"
-  cluster_cidr = "${var.cluster_cidr}"
+  name               = "${local.cluster_name}"
+  aws_region         = "${var.aws_region}"
+  kubernetes_version = "${local.kubernetes_version}"
+  service_cidr       = "${var.service_cidr}"
+  cluster_cidr       = "${var.cluster_cidr}"
 
   etcd_config = {
     instance_count   = "3"
@@ -84,10 +84,10 @@ module "kubernetes" {
 module "worker_general" {
   source = "../../aws/kube-worker-general"
 
-  name              = "${local.cluster_name}"
-  aws_region        = "${var.aws_region}"
-  version           = "${local.kubernetes_version}"
-  kube_service_cidr = "${var.service_cidr}"
+  name               = "${local.cluster_name}"
+  aws_region         = "${var.aws_region}"
+  kubernetes_version = "${local.kubernetes_version}"
+  kube_service_cidr  = "${var.service_cidr}"
 
   security_group_ids = ["${module.kubernetes.worker_sg_ids}"]
   subnet_ids         = ["${module.network.private_subnet_ids}"]
@@ -117,10 +117,10 @@ module "worker_general" {
 module "worker_spot" {
   source = "../../aws/kube-worker-mixed"
 
-  name              = "${local.cluster_name}"
-  aws_region        = "${var.aws_region}"
-  version           = "${local.kubernetes_version}"
-  kube_service_cidr = "${var.service_cidr}"
+  name               = "${local.cluster_name}"
+  aws_region         = "${var.aws_region}"
+  kubernetes_version = "${local.kubernetes_version}"
+  kube_service_cidr  = "${var.service_cidr}"
 
   security_group_ids = ["${module.kubernetes.worker_sg_ids}"]
   subnet_ids         = ["${module.network.private_subnet_ids}"]

--- a/examples/elastikube_cluster/main.tf
+++ b/examples/elastikube_cluster/main.tf
@@ -39,11 +39,11 @@ module "network" {
 module "kubernetes" {
   source = "../../aws/elastikube"
 
-  name         = "${local.cluster_name}"
-  aws_region   = "${var.aws_region}"
-  version      = "${local.kubernetes_version}"
-  service_cidr = "${var.service_cidr}"
-  cluster_cidr = "${var.cluster_cidr}"
+  name               = "${local.cluster_name}"
+  aws_region         = "${var.aws_region}"
+  kubernetes_version = "${local.kubernetes_version}"
+  service_cidr       = "${var.service_cidr}"
+  cluster_cidr       = "${var.cluster_cidr}"
 
   etcd_config = {
     instance_count   = "3"
@@ -79,10 +79,10 @@ module "kubernetes" {
 module "worker_general" {
   source = "../../aws/kube-worker-general"
 
-  name              = "${local.cluster_name}"
-  aws_region        = "${var.aws_region}"
-  version           = "${local.kubernetes_version}"
-  kube_service_cidr = "${var.service_cidr}"
+  name               = "${local.cluster_name}"
+  aws_region         = "${var.aws_region}"
+  kubernetes_version = "${local.kubernetes_version}"
+  kube_service_cidr  = "${var.service_cidr}"
 
   security_group_ids = ["${module.kubernetes.worker_sg_ids}"]
   subnet_ids         = ["${module.network.private_subnet_ids}"]
@@ -112,10 +112,10 @@ module "worker_general" {
 module "worker_spot" {
   source = "../../aws/kube-worker-mixed"
 
-  name              = "${local.cluster_name}"
-  aws_region        = "${var.aws_region}"
-  version           = "${local.kubernetes_version}"
-  kube_service_cidr = "${var.service_cidr}"
+  name               = "${local.cluster_name}"
+  aws_region         = "${var.aws_region}"
+  kubernetes_version = "${local.kubernetes_version}"
+  kube_service_cidr  = "${var.service_cidr}"
 
   security_group_ids = ["${module.kubernetes.worker_sg_ids}"]
   subnet_ids         = ["${module.network.private_subnet_ids}"]

--- a/ignitions/node-exporter/node-exporter-fetcher.tf
+++ b/ignitions/node-exporter/node-exporter-fetcher.tf
@@ -2,7 +2,7 @@ data "template_file" "node_exporter_fetcher" {
   template = "${file("${path.module}/resources/services/node-exporter-fetcher.service")}"
 
   vars {
-    version = "${var.version}"
+    version = "${var.node_exporter_version}"
   }
 }
 

--- a/ignitions/node-exporter/variables.tf
+++ b/ignitions/node-exporter/variables.tf
@@ -7,7 +7,7 @@ variable "listen_port" {
   default = 9100
 }
 
-variable "version" {
+variable "node_exporter_version" {
   type    = "string"
   default = "0.16.0"
 }


### PR DESCRIPTION
Since "version" name is reserved word in module configuration block, rename it to "kubernetes_version" and "node_exporter_version" .

ref: https://www.terraform.io/docs/configuration/variables.html#declaring-an-input-variable