### PR TITLE
modules/kube-addon-dns: use affinity to replace nodeSelector

### DIFF
--- a/modules/ignitions/kube-addon-dns/coredns-yaml.tf
+++ b/modules/ignitions/kube-addon-dns/coredns-yaml.tf
@@ -2,13 +2,39 @@ data "template_file" "coredns_yaml" {
   template = "${file("${path.module}/resources/kubernetes/manifests/coredns.yaml")}"
 
   vars {
-    image               = "${var.image}"
-    reverse_cidrs       = "${var.reverse_cidrs}"
-    cluster_dns_ip      = "${var.cluster_dns_ip}"
-    cluster_domain      = "${var.cluster_domain}"
-    federations         = "${var.federations}"
-    subdomains          = "${var.subdomains}"
-    upstream_nameserver = "${var.upstream_nameserver}"
+    image                    = "${var.image}"
+    replicas                 = "${var.replicas}"
+    reverse_cidrs            = "${var.reverse_cidrs}"
+    cluster_dns_ip           = "${var.cluster_dns_ip}"
+    cluster_domain           = "${var.cluster_domain}"
+    federations              = "${var.federations}"
+    subdomains               = "${var.subdomains}"
+    upstream_nameserver      = "${var.upstream_nameserver}"
+    located_on_the_same_host = "${var.located_on_the_same_host}"
+
+    required_pod_anti_affinity = <<EOF
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchExpressions:
+              - key: k8s-app
+                operator: In
+                values:
+                - kube-dns 
+EOF
+
+    preferred_pod_anti_affinity = <<EOF
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchExpressions:
+                - key: k8s-app
+                  operator: In
+                  values:
+                  - kube-dns 
+EOF
   }
 }
 

--- a/modules/ignitions/kube-addon-dns/resources/kubernetes/manifests/coredns.yaml
+++ b/modules/ignitions/kube-addon-dns/resources/kubernetes/manifests/coredns.yaml
@@ -77,7 +77,7 @@ metadata:
     k8s-app: kube-dns
     kubernetes.io/name: "CoreDNS"
 spec:
-  replicas: 2
+  replicas: ${replicas}
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -91,11 +91,26 @@ spec:
         k8s-app: kube-dns
     spec:
       serviceAccountName: coredns
+      priorityClassName: system-cluster-critical
       tolerations:
-        - key: "CriticalAddonsOnly"
-          operator: "Exists"
-      nodeSelector:
-        beta.kubernetes.io/os: linux
+      - key: "CriticalAddonsOnly"
+        operator: "Exists"
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: beta.kubernetes.io/os
+                operator: In
+                values:
+                - linux
+        podAntiAffinity:
+${ located_on_the_same_host ? preferred_pod_anti_affinity : required_pod_anti_affinity}
       containers:
       - name: coredns
         image: ${image}
@@ -139,12 +154,6 @@ spec:
           successThreshold: 1
           failureThreshold: 5
       dnsPolicy: Default
-      tolerations:
-      - key: "node-role.kubernetes.io/master"
-        operator: "Exists"
-        effect: "NoSchedule"
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       volumes:
         - name: config-volume
           configMap:

--- a/modules/ignitions/kube-addon-dns/variables.tf
+++ b/modules/ignitions/kube-addon-dns/variables.tf
@@ -10,6 +10,11 @@ variable "image" {
   description = "The CoreDNS image name and tag"
 }
 
+variable "replicas" {
+  default     = 2
+  description = "Number of replicas for CoreDNS pod"
+}
+
 variable "reverse_cidrs" {
   type        = "string"
   description = "CoreDNS reverse cidrs"
@@ -42,4 +47,9 @@ variable "upstream_nameserver" {
   type        = "string"
   default     = "/etc/resolv.conf"
   description = "upstream nameserver"
+}
+
+variable "located_on_the_same_host" {
+  default     = false
+  description = "Allow instances of DNS can located on the same master host"
 }


### PR DESCRIPTION
The commit replace Pod's nodeSelector to Pod's affinity. Besides, add new variables for setting pod  anti-affinity and replicas.