### PR TITLE
fix packets drop issue

### DIFF
--- a/modules/ignitions/kube-addon-proxy/conntrack.tf
+++ b/modules/ignitions/kube-addon-proxy/conntrack.tf
@@ -1,0 +1,22 @@
+# remove with update to 1.15 https://github.com/kubernetes/kubernetes/pull/74840
+# hotfix for https://kubernetes.io/blog/2019/03/29/kube-proxy-subtleties-debugging-an-intermittent-connection-reset/
+
+data "ignition_file" "module_ip_conf" {
+  filesystem = "root"
+  mode       = 420
+  path       = "/etc/modules-load.d/ip.conf"
+
+  content {
+    content = "ip_conntrack"
+  }
+}
+
+data "ignition_file" "sysctl_ip_conf" {
+  filesystem = "root"
+  mode       = 420
+  path       = "/etc/sysctl.d/ip.conf"
+
+  content {
+    content = "net.netfilter.ip_conntrack_tcp_be_liberal=1"
+  }
+}

--- a/modules/ignitions/kube-addon-proxy/outputs.tf
+++ b/modules/ignitions/kube-addon-proxy/outputs.tf
@@ -4,6 +4,8 @@ output "systemd_units" {
 
 output "files" {
   value = [
-    data.ignition_file.kube_proxy_yaml.rendered
+    data.ignition_file.kube_proxy_yaml.rendered,
+    data.ignition_file.module_ip_conf.rendered,
+    data.ignition_file.sysctl_ip_conf.rendered
   ]
 }


### PR DESCRIPTION
Fix Packets Drop Issue When K8S Version below 1.15

References:
• https://kubernetes.io/blog/2019/03/29/kube-proxy-subtleties-debugging-an-intermittent-connection-reset/
• https://stackoverflow.com/questions/58061551/coreos-ip-conntrack-tcp-be-liberal-parameter-change
• https://github.com/kubernetes/kubernetes/pull/74840/files