### PR TITLE
fix: the irsa thumbprint_list should be lower case

### DIFF
--- a/modules/aws/irsa/main.tf
+++ b/modules/aws/irsa/main.tf
@@ -20,7 +20,7 @@ resource "aws_iam_openid_connect_provider" "irsa" {
   url = "https://s3-${data.aws_region.current.name}.amazonaws.com/${var.oidc_s3_bucket}"
 
   client_id_list  = [var.oidc_api_audiences]
-  thumbprint_list = [data.external.thumbprint.result.thumbprint]
+  thumbprint_list = [lower(data.external.thumbprint.result.thumbprint)]
 }
 
 resource "local_file" "oidc_pub_key" {


### PR DESCRIPTION
The `aws_iam_openid_connect_provider resource` will store the thumbprint_list in lower case, 
  even if we set it in upper case string.

Use `lower()` function to help the string cases.