### PR TITLE
FEATURE: add type to kube flags variables

### DIFF
--- a/modules/aws/elastikube/variables.tf
+++ b/modules/aws/elastikube/variables.tf
@@ -56,6 +56,7 @@ variable "kube_extra_flags" {
 The user-provided flags to kubelet, kube-apiserver, kube-controller-manager, kube-scheduler and audit log. 
 For flags, we need to follow component flag string format. Do not use underline.
 EOF 
+  type    = map(map(string))
   default = {
     kubelet            = {}
     apiserver          = {}

--- a/modules/aws/kube-master/variables.tf
+++ b/modules/aws/kube-master/variables.tf
@@ -81,6 +81,7 @@ variable "extra_flags" {
 The user-provided flags to kubelet, kube-apiserver, kube-controller-manager, kube-scheduler and audit log. 
 For flags, we need to follow component flag string format. Do not use underline.
 EOF 
+  type    = map(map(string))
   default = {
     kubelet            = {}
     apiserver          = {}

--- a/modules/aws/kube-worker/variables.tf
+++ b/modules/aws/kube-worker/variables.tf
@@ -57,6 +57,7 @@ variable "kubelet_config" {
 
 variable "kubelet_flags" {
   description = "The flags of kubelet. The variables need to follow https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/. Do not use underline."
+  type        = map(string)
   default     = {}
 }
 


### PR DESCRIPTION
Add type to kube flags variable for
- correct type check
- better understanding for users to use modules