### PR TITLE
feat: add gp3/io2 support for etcd and master nodes

### DIFF
--- a/examples/aws-eks-distro/version.tf
+++ b/examples/aws-eks-distro/version.tf
@@ -4,7 +4,7 @@ terraform {
 
 provider "aws" {
   region  = var.aws_region
-  version = "~>3.13.0"
+  version = "~>v3.29.0"
 }
 
 provider "external" {

--- a/examples/etcd-cluster/version.tf
+++ b/examples/etcd-cluster/version.tf
@@ -4,7 +4,7 @@ terraform {
 
 provider "aws" {
   region  = var.aws_region
-  version = "~>3.13.0"
+  version = "~>v3.29.0"
 }
 
 provider "external" {

--- a/examples/iam-auth-and-irsa/example/version.tf
+++ b/examples/iam-auth-and-irsa/example/version.tf
@@ -4,7 +4,7 @@ terraform {
 
 provider "aws" {
   region  = var.aws_region
-  version = "~>3.13.0"
+  version = "~>v3.29.0"
 }
 
 provider "local" {

--- a/examples/iam-auth-and-irsa/k8s-cluster/version.tf
+++ b/examples/iam-auth-and-irsa/k8s-cluster/version.tf
@@ -4,7 +4,7 @@ terraform {
 
 provider "aws" {
   region  = var.aws_region
-  version = "~>3.13.0"
+  version = "~>v3.29.0"
 }
 
 provider "external" {

--- a/examples/kubernetes-cluster/version.tf
+++ b/examples/kubernetes-cluster/version.tf
@@ -4,7 +4,7 @@ terraform {
 
 provider "aws" {
   region  = var.aws_region
-  version = "~>3.13.0"
+  version = "~>v3.29.0"
 }
 
 provider "external" {

--- a/modules/aws/elastikube/etcd.tf
+++ b/modules/aws/elastikube/etcd.tf
@@ -6,6 +6,8 @@ module "etcd" {
   instance_config = var.etcd_instance_config
   containers      = var.override_containers
 
+  instance_volume_config = var.etcd_instance_volume_config
+
   subnet_ids                  = var.private_subnet_ids
   master_security_group_id    = module.master.master_sg_id
   zone_id                     = aws_route53_zone.private.zone_id

--- a/modules/aws/elastikube/variables.tf
+++ b/modules/aws/elastikube/variables.tf
@@ -282,6 +282,33 @@ variable "etcd_instance_config" {
   }
 }
 
+variable "etcd_instance_volume_config" {
+  type = object({
+    root = object({
+      type       = string
+      iops       = number
+      throughput = number
+    })
+    data = object({
+      type       = string
+      iops       = number
+      throughput = number
+    })
+  })
+  default = {
+    root = {
+      type       = "gp2"
+      iops       = 0
+      throughput = 0
+    }
+    data = {
+      type       = "gp2"
+      iops       = 0
+      throughput = 0
+    }
+  }
+}
+
 variable "ssh_key" {
   description = "The key name that should be used for the instances."
   type        = string

--- a/modules/aws/kube-etcd/main.tf
+++ b/modules/aws/kube-etcd/main.tf
@@ -57,9 +57,9 @@ resource "aws_ebs_volume" "etcd" {
   availability_zone = data.aws_subnet.etcd[count.index].availability_zone
   size              = var.instance_config["data_volume_size"]
   type              = var.instance_volume_config.data.type
-  iops              = lookup(local.iops_by_type.data, var.instance_volume_config.data.type, 0)
+  iops              = lookup(local.iops_by_type.data, var.instance_volume_config.data.type, null)
   # aws_ebs_volume always checks the range of throughput.(125 ~ 1000)
-  throughput        = lookup(local.throughput_by_type.data, var.instance_volume_config.data.type, 125)
+  throughput        = lookup(local.throughput_by_type.data, var.instance_volume_config.data.type, null)
 
   tags = merge(var.extra_tags, map(
     "Name", "${var.name}-etcd-${count.index}",
@@ -93,8 +93,8 @@ resource "aws_instance" "etcd" {
   root_block_device {
     volume_size = var.instance_config["root_volume_size"]
     volume_type = var.instance_volume_config.root.type
-    iops        = lookup(local.iops_by_type.root, var.instance_volume_config.root.type, 0)
-    throughput  = lookup(local.throughput_by_type.root, var.instance_volume_config.root.type, 0)
+    iops        = lookup(local.iops_by_type.root, var.instance_volume_config.root.type, null)
+    throughput  = lookup(local.throughput_by_type.root, var.instance_volume_config.root.type, null)
   }
 
   volume_tags = merge(var.extra_tags, map(

--- a/modules/aws/kube-etcd/main.tf
+++ b/modules/aws/kube-etcd/main.tf
@@ -58,7 +58,8 @@ resource "aws_ebs_volume" "etcd" {
   size              = var.instance_config["data_volume_size"]
   type              = var.instance_volume_config.data.type
   iops              = lookup(local.iops_by_type.data, var.instance_volume_config.data.type, 0)
-  throughput        = lookup(local.throughput_by_type.data, var.instance_volume_config.data.type, 0)
+  # aws_ebs_volume always checks the range of throughput.(125 ~ 1000)
+  throughput        = lookup(local.throughput_by_type.data, var.instance_volume_config.data.type, 125)
 
   tags = merge(var.extra_tags, map(
     "Name", "${var.name}-etcd-${count.index}",

--- a/modules/aws/kube-etcd/variables.tf
+++ b/modules/aws/kube-etcd/variables.tf
@@ -124,12 +124,12 @@ variable "instance_volume_config" {
 
   default = {
     root = {
-      type       = "gp3"
+      type       = "gp2"
       iops       = 0
       throughput = 0
     }
     data = {
-      type       = "gp3"
+      type       = "gp2"
       iops       = 0
       throughput = 0
     }

--- a/modules/aws/kube-etcd/variables.tf
+++ b/modules/aws/kube-etcd/variables.tf
@@ -108,6 +108,34 @@ variable "instance_config" {
   })
 }
 
+variable "instance_volume_config" {
+  type = object({
+    root = object({
+      type       = string
+      iops       = number
+      throughput = number
+    })
+    data = object({
+      type       = string
+      iops       = number
+      throughput = number
+    })
+  })
+
+  default = {
+    root = {
+      type       = "gp3"
+      iops       = 0
+      throughput = 0
+    }
+    data = {
+      type       = "gp3"
+      iops       = 0
+      throughput = 0
+    }
+  }
+}
+
 variable "ssh_key" {
   description = "The key name that should be used for the instances."
   type        = string

--- a/modules/aws/kube-master/main.tf
+++ b/modules/aws/kube-master/main.tf
@@ -5,16 +5,16 @@ locals {
   extra_tags_values = values(var.extra_tags)
 
   iops_by_type       = {
-    "gp2": min(10000, max(100, 3 * var.instance_config["root_volume_size"])),
-    "gp3": max(3000, var.instance_config["root_volume_iops"]),
-    "io1": max(100, var.instance_config["root_volume_iops"]),
-    "io2": max(100, var.instance_config["root_volume_iops"]),
+    root = {
+      "gp3": max(3000, var.instance_config["root_volume_iops"]),
+      "io1": max(100, var.instance_config["root_volume_iops"]),
+      "io2": max(100, var.instance_config["root_volume_iops"]),
+    }
   }
   throughput_by_type = {
-    "gp2": 0,
-    "gp3": 125,
-    "io1": 0,
-    "io2": 0,
+    root = {
+      "gp3": 125,
+    }
   }
 }
 
@@ -100,8 +100,8 @@ resource "aws_launch_template" "master" {
     ebs {
       volume_type = var.instance_config["root_volume_type"]
       volume_size = var.instance_config["root_volume_size"]
-      iops        = lookup(local.iops_by_type, var.instance_config["root_volume_type"], 0)
-      throughput  = lookup(local.throughput_by_type, var.instance_config["root_volume_type"], 0)
+      iops        = lookup(local.iops_by_type.root, var.instance_config["root_volume_type"], 0)
+      throughput  = lookup(local.throughput_by_type.root, var.instance_config["root_volume_type"], 0)
     }
   }
 

--- a/modules/aws/kube-master/main.tf
+++ b/modules/aws/kube-master/main.tf
@@ -3,6 +3,19 @@ locals {
 
   extra_tags_keys   = keys(var.extra_tags)
   extra_tags_values = values(var.extra_tags)
+
+  iops_by_type       = {
+    "gp2": min(10000, max(100, 3 * var.instance_config["root_volume_size"])),
+    "gp3": max(3000, var.instance_config["root_volume_iops"]),
+    "io1": max(100, var.instance_config["root_volume_iops"]),
+    "io2": max(100, var.instance_config["root_volume_iops"]),
+  }
+  throughput_by_type = {
+    "gp2": 0,
+    "gp3": 125,
+    "io1": 0,
+    "io2": 0,
+  }
 }
 
 data "aws_subnet" "subnet" {
@@ -87,7 +100,8 @@ resource "aws_launch_template" "master" {
     ebs {
       volume_type = var.instance_config["root_volume_type"]
       volume_size = var.instance_config["root_volume_size"]
-      iops        = var.instance_config["root_volume_type"] == "io1" ? var.instance_config["root_volume_iops"] : var.instance_config["root_volume_type"] == "gp2" ? 0 : min(10000, max(100, 3 * var.instance_config["root_volume_size"]))
+      iops        = lookup(local.iops_by_type, var.instance_config["root_volume_type"], 0)
+      throughput  = lookup(local.throughput_by_type, var.instance_config["root_volume_type"], 0)
     }
   }
 

--- a/modules/aws/kube-master/main.tf
+++ b/modules/aws/kube-master/main.tf
@@ -100,8 +100,8 @@ resource "aws_launch_template" "master" {
     ebs {
       volume_type = var.instance_config["root_volume_type"]
       volume_size = var.instance_config["root_volume_size"]
-      iops        = lookup(local.iops_by_type.root, var.instance_config["root_volume_type"], 0)
-      throughput  = lookup(local.throughput_by_type.root, var.instance_config["root_volume_type"], 0)
+      iops        = lookup(local.iops_by_type.root, var.instance_config["root_volume_type"], null)
+      throughput  = lookup(local.throughput_by_type.root, var.instance_config["root_volume_type"], null)
     }
   }
 


### PR DESCRIPTION
- Add volume type supporting for etcd and master nodes.
    - Avoid break changes
    - Add etcd_instance_volume_config for elastikube to support volume type
- Perfer aws provider `v3.29.0` which fixed [gp2/gp3 issue](https://github.com/hashicorp/terraform-provider-aws/issues/17644).