### PR TITLE
feat: mitigate that always have to update irsa s3_object

### DIFF
--- a/modules/aws/irsa/main.tf
+++ b/modules/aws/irsa/main.tf
@@ -40,7 +40,8 @@ resource "null_resource" "generate_oidc_keys_json" {
   }
 
   triggers = {
-    controller_primary = timestamp()
+    oidc_pub_key_md5 = md5(var.oidc_pub_key)
+    is_exist         = fileexists("${path.root}/.secret/keys.json")
   }
 
   depends_on = [local_file.oidc_pub_key]
@@ -81,7 +82,7 @@ resource "aws_s3_bucket_object" "keys_json" {
   bucket = aws_s3_bucket.oidc.id
 
   key          = "keys.json"
-  content      = data.local_file.keys_json.content
+  content      = fileexists("${path.root}/.secret/keys.json") ? file("${path.root}/.secret/keys.json") : data.local_file.keys_json.content
   acl          = "public-read"
   content_type = "application/json"
 


### PR DESCRIPTION
- Fixed:
    - Use the `file()` with `fileexists()` to avoid read from the unstable `data.local_file` source.
        - If file doesn't exist, fallback to the `data.local_file` source.
- Potential Issues:
    - The s3_object might be incorrect if the `keys.json` has been changed **externally**.
        - run `apply` again might not fix this case, since the `null_resource` triggers cannot handle this issue,
        - delete the `keys.json` file might be the only way.
    - The trigger `local_cache_exist` of `null_resource` would keep wrong states, and trigger local file updating.
        - from scratch => local_cache_exist: `null` -> `false`
        - run again => local_cache_exist: `false` -> `true`
        - run again => local_cache_exist: `true`