### PR TITLE
Release with k8s v1.19.8

### DIFF
--- a/modules/aws/iam-authenticator/main.tf
+++ b/modules/aws/iam-authenticator/main.tf
@@ -1,5 +1,5 @@
 module "ignition_iam_auth" {
-  source = "git::ssh://git@github.com/getamis/terraform-ignition-kubernetes//modules/extra-addons/aws-iam-authenticator?ref=master"
+  source = "git::ssh://git@github.com/getamis/terraform-ignition-kubernetes//modules/extra-addons/aws-iam-authenticator?ref=v1.1.0"
 
   cluster_name        = var.name
   container           = var.container

--- a/modules/aws/irsa/main.tf
+++ b/modules/aws/irsa/main.tf
@@ -11,7 +11,7 @@ locals {
 data "aws_region" "current" {}
 
 module "ignition_pod_idenity_webhook" {
-  source = "git::ssh://git@github.com/getamis/terraform-ignition-kubernetes//modules/extra-addons/aws-pod-identity-webhook?ref=master"
+  source = "git::ssh://git@github.com/getamis/terraform-ignition-kubernetes//modules/extra-addons/aws-pod-identity-webhook?ref=v1.1.0"
 
   container             = var.container
   webhook_flags         = var.webhook_flags

--- a/modules/aws/kube-etcd/ignition.tf
+++ b/modules/aws/kube-etcd/ignition.tf
@@ -1,22 +1,22 @@
 module "ignition_docker" {
-  source = "git::ssh://git@github.com/getamis/terraform-ignition-reinforcements//modules/docker?ref=master"
+  source = "git::ssh://git@github.com/getamis/terraform-ignition-reinforcements//modules/docker?ref=v1.1.1"
 }
 
 module "ignition_locksmithd" {
-  source          = "git::ssh://git@github.com/getamis/terraform-ignition-reinforcements//modules/locksmithd?ref=master"
+  source          = "git::ssh://git@github.com/getamis/terraform-ignition-reinforcements//modules/locksmithd?ref=v1.1.1"
   reboot_strategy = var.reboot_strategy
 }
 
 module "ignition_update_ca_certificates" {
-  source = "git::ssh://git@github.com/getamis/terraform-ignition-reinforcements//modules/update-ca-certificates?ref=master"
+  source = "git::ssh://git@github.com/getamis/terraform-ignition-reinforcements//modules/update-ca-certificates?ref=v1.1.1"
 }
 
 module "ignition_node_exporter" {
-  source = "git::ssh://git@github.com/getamis/terraform-ignition-reinforcements//modules/node-exporter?ref=master"
+  source = "git::ssh://git@github.com/getamis/terraform-ignition-reinforcements//modules/node-exporter?ref=v1.1.1"
 }
 
 module "ignition_etcd" {
-  source = "git::ssh://git@github.com/getamis/terraform-ignition-etcd?ref=master"
+  source = "git::ssh://git@github.com/getamis/terraform-ignition-etcd?ref=v1.1.0"
 
   name                  = var.name
   containers            = var.containers

--- a/modules/aws/kube-master/ignition.tf
+++ b/modules/aws/kube-master/ignition.tf
@@ -12,7 +12,7 @@ resource "random_password" "encryption_secret" {
 }
 
 module "ignition_kubernetes" {
-  source = "git::ssh://git@github.com/getamis/terraform-ignition-kubernetes?ref=master"
+  source = "git::ssh://git@github.com/getamis/terraform-ignition-kubernetes?ref=v1.1.0"
 
   binaries              = var.binaries
   containers            = var.containers
@@ -90,16 +90,16 @@ module "ignition_kubernetes" {
 }
 
 module "ignition_docker" {
-  source = "git::ssh://git@github.com/getamis/terraform-ignition-reinforcements//modules/docker?ref=master"
+  source = "git::ssh://git@github.com/getamis/terraform-ignition-reinforcements//modules/docker?ref=v1.1.1"
 }
 
 module "ignition_locksmithd" {
-  source          = "git::ssh://git@github.com/getamis/terraform-ignition-reinforcements//modules/locksmithd?ref=master"
+  source          = "git::ssh://git@github.com/getamis/terraform-ignition-reinforcements//modules/locksmithd?ref=v1.1.1"
   reboot_strategy = var.reboot_strategy
 }
 
 module "ignition_update_ca_certificates" {
-  source = "git::ssh://git@github.com/getamis/terraform-ignition-reinforcements//modules/update-ca-certificates?ref=master"
+  source = "git::ssh://git@github.com/getamis/terraform-ignition-reinforcements//modules/update-ca-certificates?ref=v1.1.1"
 }
 
 data "ignition_config" "main" {

--- a/modules/aws/kube-worker/ignition.tf
+++ b/modules/aws/kube-worker/ignition.tf
@@ -8,16 +8,16 @@ locals {
 }
 
 module "ignition_docker" {
-  source = "git::ssh://git@github.com/getamis/terraform-ignition-reinforcements//modules/docker?ref=master"
+  source = "git::ssh://git@github.com/getamis/terraform-ignition-reinforcements//modules/docker?ref=v1.1.1"
 }
 
 module "ignition_locksmithd" {
-  source          = "git::ssh://git@github.com/getamis/terraform-ignition-reinforcements//modules/locksmithd?ref=master"
+  source          = "git::ssh://git@github.com/getamis/terraform-ignition-reinforcements//modules/locksmithd?ref=v1.1.1"
   reboot_strategy = var.reboot_strategy
 }
 
 module "ignition_update_ca_certificates" {
-  source = "git::ssh://git@github.com/getamis/terraform-ignition-reinforcements//modules/update-ca-certificates?ref=master"
+  source = "git::ssh://git@github.com/getamis/terraform-ignition-reinforcements//modules/update-ca-certificates?ref=v1.1.1"
 }
 
 data "aws_s3_bucket_object" "bootstrapping_kubeconfig" {
@@ -26,7 +26,7 @@ data "aws_s3_bucket_object" "bootstrapping_kubeconfig" {
 }
 
 module "ignition_kubelet" {
-  source = "git::ssh://git@github.com/getamis/terraform-ignition-kubernetes//modules/kubelet"
+  source = "git::ssh://git@github.com/getamis/terraform-ignition-kubernetes//modules/kubelet?ref=v1.1.0"
 
   binaries             = var.binaries
   containers           = var.containers


### PR DESCRIPTION
Release vishwakarma: v1.1.0

Lock versions
- terraform-ignition-etcs v1.1.0
- terraform-ignition-kubernetes v1.1.0
- terraform-ignition-reinforcements v1.1.1
- tf-aws-containeros v0.1.0
- tf-null-label v0.0.4