### PR TITLE
Fix: irsa issues

### DIFF
--- a/examples/iam-auth-and-irsa/k8s-cluster/main.tf
+++ b/examples/iam-auth-and-irsa/k8s-cluster/main.tf
@@ -33,6 +33,8 @@ module "irsa" {
   name           = module.label.id
   oidc_s3_bucket = "oidc-${md5(module.label.id)}"
   oidc_pub_key   = module.service_account.public_key_pem
+
+  webhook_ca_bundle = module.master.kubernetes_ca_cert
 }
 
 module "iam_auth" {

--- a/modules/aws/elastikube/outputs.tf
+++ b/modules/aws/elastikube/outputs.tf
@@ -52,3 +52,9 @@ output "service_account_pub_key" {
   sensitive = true
   value     = var.service_account_content.pub_key == "" ? module.master.service_account_pub_key : var.service_account_content.pub_key
 }
+
+output "kubernetes_ca_cert" {
+  sensitive = true
+  value     = module.master.kubernetes_ca_cert
+}
+

--- a/modules/aws/irsa/main.tf
+++ b/modules/aws/irsa/main.tf
@@ -11,17 +11,15 @@ locals {
 data "aws_region" "current" {}
 
 module "ignition_pod_idenity_webhook" {
-  #source = "git::ssh://git@github.com/getamis/terraform-ignition-kubernetes//modules/extra-addons/aws-pod-identity-webhook?ref=v1.1.0"
-  #FIXME
-  source = "git::ssh://git@github.com/soem/terraform-ignition-kubernetes//modules/extra-addons/aws-pod-identity-webhook?ref=test"
+  source = "git::ssh://git@github.com/getamis/terraform-ignition-kubernetes//modules/extra-addons/aws-pod-identity-webhook?ref=v1.2.0"
 
-  container             = var.container
-  webhook_flags         = var.webhook_flags
-  addons_dir_path       = var.kube_addons_dir_path
+  container                  = var.container
+  webhook_flags              = var.webhook_flags
+  addons_dir_path            = var.kube_addons_dir_path
   mutating_webhook_ca_bundle = var.webhook_ca_bundle
-  tls_cert              = module.webhook_cert.cert_pem
-  tls_key               = module.webhook_cert.private_key_pem
-  located_control_plane = true
+  tls_cert                   = module.webhook_cert.cert_pem
+  tls_key                    = module.webhook_cert.private_key_pem
+  located_control_plane      = true
 }
 
 data "external" "thumbprint" {

--- a/modules/aws/irsa/main.tf
+++ b/modules/aws/irsa/main.tf
@@ -16,7 +16,7 @@ module "ignition_pod_idenity_webhook" {
   container             = var.container
   webhook_flags         = var.webhook_flags
   addons_dir_path       = var.kube_addons_dir_path
-  tls_cert_ca           = module.webhook_ca.cert_pem
+  tls_cert_ca           = var.webhook_ca_bundle
   tls_cert              = module.webhook_cert.cert_pem
   tls_key               = module.webhook_cert.private_key_pem
   located_control_plane = true

--- a/modules/aws/irsa/main.tf
+++ b/modules/aws/irsa/main.tf
@@ -11,12 +11,14 @@ locals {
 data "aws_region" "current" {}
 
 module "ignition_pod_idenity_webhook" {
-  source = "git::ssh://git@github.com/getamis/terraform-ignition-kubernetes//modules/extra-addons/aws-pod-identity-webhook?ref=v1.1.0"
+  #source = "git::ssh://git@github.com/getamis/terraform-ignition-kubernetes//modules/extra-addons/aws-pod-identity-webhook?ref=v1.1.0"
+  #FIXME
+  source = "git::ssh://git@github.com/soem/terraform-ignition-kubernetes//modules/extra-addons/aws-pod-identity-webhook?ref=test"
 
   container             = var.container
   webhook_flags         = var.webhook_flags
   addons_dir_path       = var.kube_addons_dir_path
-  tls_cert_ca           = var.webhook_ca_bundle
+  mutating_webhook_ca_bundle = var.webhook_ca_bundle
   tls_cert              = module.webhook_cert.cert_pem
   tls_key               = module.webhook_cert.private_key_pem
   located_control_plane = true

--- a/modules/aws/irsa/variables.tf
+++ b/modules/aws/irsa/variables.tf
@@ -8,7 +8,7 @@ variable "container" {
   type        = map(string)
   default = {
     repo = "quay.io/amis/aws-pod-identity-webhook"
-    tag  = "v0.2.0"
+    tag  = "ed8c41f"
   }
 }
 

--- a/modules/aws/irsa/variables.tf
+++ b/modules/aws/irsa/variables.tf
@@ -24,6 +24,11 @@ variable "pki_dir_path" {
   default     = "/etc/kubernetes/pki/pod-identity-webhook"
 }
 
+variable "webhook_ca_bundle" {
+  description = "The ca bundle for mutatingwebhookconfigurations of pod identity webhook."
+  type        = string
+}
+
 variable "webhook_flags" {
   description = "The flags of pod identity webhook. The variables need to follow https://github.com/aws/amazon-eks-pod-identity-webhook/blob/master/main.go. Do not use underline."
   default     = {}


### PR DESCRIPTION
- Upgrade `aws-pod-identity-webhook` image to fix k8s v1.19 issue
    - https://github.com/aws/amazon-eks-pod-identity-webhook/issues/89
- Set the correct `mutatingwebhookconfigurations` ca_bundle
    - The ca_bundle should get from module `elastikube` output `kubernetes_ca_cert`
    - Upgrade module `aws-pod-identity-webhook` to v1.2.0