### PR TITLE
FEATURE: Upgrade aws-pod-identity-webhook module to improve availability

### DIFF
--- a/modules/aws/irsa/main.tf
+++ b/modules/aws/irsa/main.tf
@@ -11,11 +11,12 @@ locals {
 data "aws_region" "current" {}
 
 module "ignition_pod_idenity_webhook" {
-  source = "git::ssh://git@github.com/getamis/terraform-ignition-kubernetes//modules/extra-addons/aws-pod-identity-webhook?ref=v1.4.0"
+  source = "git::ssh://git@github.com/getamis/terraform-ignition-kubernetes//modules/extra-addons/aws-pod-identity-webhook?ref=v1.4.1"
 
   container                  = var.container
   service_name               = var.service_name
   namespace                  = var.namespace
+  replicas                   = var.replicas
   webhook_flags              = var.webhook_flags
   addons_dir_path            = var.kube_addons_dir_path
   mutating_webhook_ca_bundle = module.webhook_ca.cert_pem

--- a/modules/aws/irsa/variables.tf
+++ b/modules/aws/irsa/variables.tf
@@ -24,6 +24,12 @@ variable "namespace" {
   default     = "kube-system"
 }
 
+variable "replicas" {
+  description = "The pod identity webhook deployment replicas"
+  type        = number
+  default     = 1
+}
+
 variable "kube_addons_dir_path" {
   description = "A path for installing addons."
   type        = string


### PR DESCRIPTION
- Upgrade `terraform-ignition-kubernetes` module to v1.4.1
- Add `replicas` variable for [aws-pod-identity-webhook](https://github.com/getamis/terraform-ignition-kubernetes/pull/38)