### PR TITLE
FEATURE: support aws node termination handler & allow instance count set to zero

### DIFF
--- a/modules/aws/kube-worker/main.tf
+++ b/modules/aws/kube-worker/main.tf
@@ -24,7 +24,7 @@ data "aws_subnet" "subnet" {
 resource "aws_autoscaling_group" "worker" {
   name_prefix         = "${var.name}-worker-${var.instance_config["name"]}-"
   desired_capacity    = var.instance_config["count"]
-  max_size            = var.instance_config["count"] * 3
+  max_size            = var.instance_config["count"] == 0 ? 3 : (var.instance_config["count"] * 3)
   min_size            = var.instance_config["count"]
   vpc_zone_identifier = var.subnet_ids
 
@@ -96,7 +96,8 @@ resource "aws_autoscaling_group" "worker" {
   lifecycle {
     ignore_changes = [
       load_balancers,
-      target_group_arns
+      target_group_arns,
+      desired_capacity
     ]
   }
 }

--- a/modules/aws/kube-worker/main.tf
+++ b/modules/aws/kube-worker/main.tf
@@ -76,9 +76,14 @@ resource "aws_autoscaling_group" "worker" {
       value               = "k8s-worker"
       propagate_at_launch = true
     },
-    {
+    (var.enable_autoscaler != "true" ) ? {} : {
       key                 = "k8s.io/cluster-autoscaler/enabled"
-      value               = "${var.enable_autoscaler}"
+      value               = "true"
+      propagate_at_launch = true
+    },
+    (var.enable_node_termination_handler != "true" ) ? {} : {
+      key                 = "aws-node-termination-handler/managed"
+      value               = "true"
       propagate_at_launch = true
     },
     (var.instance_spot_max_price == "") ? {} : {

--- a/modules/aws/kube-worker/variables.tf
+++ b/modules/aws/kube-worker/variables.tf
@@ -152,6 +152,12 @@ variable "enable_autoscaler" {
   default     = "false"
 }
 
+variable "enable_node_termination_handler" {
+  description = "Enable to add aws-node-termination-handler tag or not"
+  type        = string
+  default     = "false"
+}
+
 variable "ssh_key" {
   description = "The key name that should be used for the instance."
   type        = string


### PR DESCRIPTION
- handle the case of `instance_config['count']` is 0, will set the ASG max_size to 3.
- ignore `desired_capacity` change, prevent unexpected scale-down worker nodes. 
- add `enable_node_termination_handler` flag for aws-node-termination-handler.