### PR TITLE
FIX: kube-worker module created duplicate worker role

### DIFF
--- a/modules/aws/kube-worker/outputs.tf
+++ b/modules/aws/kube-worker/outputs.tf
@@ -7,7 +7,7 @@ output "worker_launch_template_name" {
 }
 
 output "worker_role_name" {
-  value = aws_iam_role.worker.name
+  value = length(aws_iam_role.worker[*].name) > 0 ? aws_iam_role.worker[0].name : var.role_name
 }
 
 output "worker_instance_profile_name" {

--- a/modules/aws/kube-worker/role.tf
+++ b/modules/aws/kube-worker/role.tf
@@ -14,7 +14,8 @@ data "aws_iam_policy_document" "worker_profile" {
 }
 
 resource "aws_iam_role" "worker" {
-  name_prefix        = "${var.name}-worker-"
+  count              = var.role_name == "" ? 1 : 0
+  name_prefix        = "${var.name}-worker-${var.instance_config["name"]}-"
   assume_role_policy = data.aws_iam_policy_document.worker_profile.json
 }
 
@@ -115,11 +116,11 @@ resource "aws_iam_policy" "worker_vpc_cni" {
 resource "aws_iam_role_policy_attachment" "worker" {
   count      = var.role_name == "" ? 1 : 0
   policy_arn = aws_iam_policy.worker[0].arn
-  role       = aws_iam_role.worker.name
+  role       = var.role_name == "" ? aws_iam_role.worker[0].name : var.role_name
 }
 
 resource "aws_iam_role_policy_attachment" "worker_vpc_cni" {
   count      = var.network_plugin == "amazon-vpc" ? 1 : 0
   policy_arn = aws_iam_policy.worker_vpc_cni[0].arn
-  role       = aws_iam_role.worker.name
+  role       = var.role_name == "" ? aws_iam_role.worker[0].name : var.role_name
 }


### PR DESCRIPTION
- no longer create duplicate worker iam role when `var.role_name` is set.