### PR TITLE
FEATURE: Improve Kubernetes control plane components stability

### DIFF
--- a/docs/variables/aws/kube-worker.md
+++ b/docs/variables/aws/kube-worker.md
@@ -17,7 +17,7 @@ No requirements.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_ignition_docker"></a> [ignition\_docker](#module\_ignition\_docker) | github.com/getamis/terraform-ignition-reinforcements//modules/docker | v1.1.3 |
-| <a name="module_ignition_kubelet"></a> [ignition\_kubelet](#module\_ignition\_kubelet) | github.com/getamis/terraform-ignition-kubernetes//modules/kubelet | v1.4.9 |
+| <a name="module_ignition_kubelet"></a> [ignition\_kubelet](#module\_ignition\_kubelet) | github.com/getamis/terraform-ignition-kubernetes//modules/kubelet | v1.4.10 |
 | <a name="module_ignition_locksmithd"></a> [ignition\_locksmithd](#module\_ignition\_locksmithd) | github.com/getamis/terraform-ignition-reinforcements//modules/locksmithd | v1.1.3 |
 | <a name="module_ignition_sshd"></a> [ignition\_sshd](#module\_ignition\_sshd) | github.com/getamis/terraform-ignition-reinforcements//modules/sshd | v1.1.3 |
 | <a name="module_ignition_systemd_networkd"></a> [ignition\_systemd\_networkd](#module\_ignition\_systemd\_networkd) | github.com/getamis/terraform-ignition-reinforcements//modules/systemd-networkd | v1.1.3 |

--- a/modules/aws/iam-authenticator/main.tf
+++ b/modules/aws/iam-authenticator/main.tf
@@ -1,5 +1,5 @@
 module "ignition_iam_auth" {
-  source = "github.com/getamis/terraform-ignition-kubernetes//modules/extra-addons/aws-iam-authenticator?ref=v1.4.9"
+  source = "github.com/getamis/terraform-ignition-kubernetes//modules/extra-addons/aws-iam-authenticator?ref=v1.4.10"
 
   cluster_name        = var.name
   container           = var.container

--- a/modules/aws/irsa/main.tf
+++ b/modules/aws/irsa/main.tf
@@ -11,7 +11,7 @@ locals {
 data "aws_region" "current" {}
 
 module "ignition_pod_idenity_webhook" {
-  source = "github.com/getamis/terraform-ignition-kubernetes//modules/extra-addons/aws-pod-identity-webhook?ref=v1.4.9"
+  source = "github.com/getamis/terraform-ignition-kubernetes//modules/extra-addons/aws-pod-identity-webhook?ref=v1.4.10"
 
   container                  = var.container
   service_name               = var.service_name

--- a/modules/aws/kube-master/ignition.tf
+++ b/modules/aws/kube-master/ignition.tf
@@ -12,7 +12,7 @@ resource "random_password" "encryption_secret" {
 }
 
 module "ignition_kubernetes" {
-  source = "github.com/getamis/terraform-ignition-kubernetes?ref=v1.4.9"
+  source = "github.com/getamis/terraform-ignition-kubernetes?ref=v1.4.10"
 
   binaries              = var.binaries
   containers            = var.containers

--- a/modules/aws/kube-worker/ignition.tf
+++ b/modules/aws/kube-worker/ignition.tf
@@ -38,7 +38,7 @@ data "aws_s3_bucket_object" "bootstrapping_kubeconfig" {
 }
 
 module "ignition_kubelet" {
-  source = "github.com/getamis/terraform-ignition-kubernetes//modules/kubelet?ref=v1.4.9"
+  source = "github.com/getamis/terraform-ignition-kubernetes//modules/kubelet?ref=v1.4.10"
 
   binaries             = var.binaries
   containers           = var.containers


### PR DESCRIPTION
`terraform-ignition-kubernetes@v1.4.10`
- fix: increase aws-iam-authenticator memory to prevent oomkill
- fix: set kube-apiserver qos class to guaranteed to prevent unexpected eviction

Ref: https://github.com/getamis/terraform-ignition-kubernetes/pull/48