### PR TITLE
FIX: only primary sg can be tagged as owned by the cluster

### DIFF
--- a/modules/aws/kube-worker/sg.tf
+++ b/modules/aws/kube-worker/sg.tf
@@ -7,7 +7,6 @@ resource "aws_security_group" "worker_group" {
 
   tags = merge(var.extra_tags, map(
     "Name", "${var.name}-worker-${var.instance_config["name"]}",
-    "kubernetes.io/cluster/${var.name}", "owned",
     "Role", "k8s-worker"
   ))
 }


### PR DESCRIPTION
AWS reuses the cluster tag for determining the primary security group of an instance.

Ref: https://github.com/kubernetes/kubernetes/issues/73906