### PR TITLE
FEATURE: add annotate_pod_ip and components_resource variables

### DIFF
--- a/modules/aws/elastikube/main.tf
+++ b/modules/aws/elastikube/main.tf
@@ -16,10 +16,11 @@ module "master" {
   endpoint_public_access = var.endpoint_public_access
   s3_bucket              = aws_s3_bucket.ignition.id
 
-  containers         = var.override_containers
-  binaries           = var.override_binaries
-  kubernetes_version = var.kubernetes_version
-  network_plugin     = var.network_plugin
+  containers          = var.override_containers
+  binaries            = var.override_binaries
+  components_resource = var.override_components_resource
+  kubernetes_version  = var.kubernetes_version
+  network_plugin      = var.network_plugin
 
   etcd_endpoints          = module.etcd.endpoints
   service_account_content = var.service_account_content
@@ -58,6 +59,7 @@ module "master" {
   oidc_config = var.irsa_oidc_config
 
   enable_eni_prefix = var.enable_eni_prefix
+  annotate_pod_ip   = var.annotate_pod_ip
   max_pods          = var.max_pods
 
   audit_log_policy_content = var.kube_audit_log_policy_content

--- a/modules/aws/elastikube/variables.tf
+++ b/modules/aws/elastikube/variables.tf
@@ -27,6 +27,16 @@ variable "override_containers" {
   default = {}
 }
 
+variable "override_components_resource" {
+  description = "Desired resource requests and limits of kubernetes components(kube-apiserver, kube-controller-manager, kube-scheduler, etc.)"
+  type = map(object({
+    cpu_request    = string
+    cpu_limit      = string
+    memory_request = string
+    memory_limit   = string
+  }))
+  default = {}
+}
 variable "kube_apiserver_secure_port" {
   description = "The port on which to serve HTTPS with authentication and authorization for kube-apiserver."
   type        = number
@@ -236,6 +246,12 @@ variable "enable_eni_prefix" {
   description = "(Optional) assign prefix to AWS EC2 network interface"
   type        = bool
   default     = true
+}
+
+variable "annotate_pod_ip" {
+  description = "(Optional) enable to fix pod startup connectivity issue on installing Calico with aws-vpc-cni plugin. (Issue: https://github.com/aws/amazon-vpc-cni-k8s/issues/493)"
+  type        = bool
+  default     = false
 }
 
 variable "max_pods" {

--- a/modules/aws/kube-master/ignition.tf
+++ b/modules/aws/kube-master/ignition.tf
@@ -12,7 +12,7 @@ resource "random_password" "encryption_secret" {
 }
 
 module "ignition_kubernetes" {
-  source = "github.com/getamis/terraform-ignition-kubernetes?ref=v1.4.12"
+  source = "github.com/getamis/terraform-ignition-kubernetes?ref=v1.4.13"
 
   binaries              = var.binaries
   containers            = var.containers
@@ -49,6 +49,7 @@ module "ignition_kubernetes" {
   apiserver_flags          = var.kube_extra_flags["apiserver"]
   controller_manager_flags = var.kube_extra_flags["controller_manager"]
   scheduler_flags          = var.kube_extra_flags["scheduler"]
+  components_resource      = var.components_resource
   audit_log_flags          = var.kube_extra_flags["audit_log"]
   audit_log_policy_content = var.audit_log_policy_content
   encryption_secret        = random_password.encryption_secret.result
@@ -57,6 +58,7 @@ module "ignition_kubernetes" {
   enable_irsa              = var.enable_irsa
   oidc_config              = var.oidc_config
   enable_eni_prefix        = var.enable_eni_prefix
+  annotate_pod_ip          = var.annotate_pod_ip
   max_pods                 = var.max_pods
 
   certs = {

--- a/modules/aws/kube-master/variables.tf
+++ b/modules/aws/kube-master/variables.tf
@@ -27,6 +27,17 @@ variable "containers" {
   default = {}
 }
 
+variable "components_resource" {
+  description = "Desired resource requests and limits of kubernetes components(kube-apiserver, kube-controller-manager, kube-scheduler, etc.)"
+  type = map(object({
+    cpu_request    = string
+    cpu_limit      = string
+    memory_request = string
+    memory_limit   = string
+  }))
+  default = {}
+}
+
 variable "network_plugin" {
   description = "Desired network plugin which is use for Kubernetes cluster. e.g. 'flannel', 'amazon-vpc'"
   type        = string
@@ -232,6 +243,12 @@ variable "enable_eni_prefix" {
   description = "(Optional) assign prefix to AWS EC2 network interface"
   type        = bool
   default     = true
+}
+
+variable "annotate_pod_ip" {
+  description = "(Optional) enable to fix pod startup connectivity issue on installing Calico with aws-vpc-cni plugin. (Issue: https://github.com/aws/amazon-vpc-cni-k8s/issues/493)"
+  type        = bool
+  default     = false
 }
 
 variable "max_pods" {


### PR DESCRIPTION
- Add annotate_pod_ip knob for aws-vpc-cni to fix https://github.com/aws/amazon-vpc-cni-k8s/issues/493.
- Upgrade aws-vpc-cni to v1.11.0.
- Add components_resource variable to manage resource requests and limits of components.

Blocked by https://github.com/getamis/terraform-ignition-kubernetes/pull/53 merge and tag `v1.4.13`.