### PR TITLE
FEATURE: support etcd-metrics-proxy

### DIFF
--- a/modules/aws/kube-etcd/ignition.tf
+++ b/modules/aws/kube-etcd/ignition.tf
@@ -23,7 +23,7 @@ module "ignition_sshd" {
 }
 
 module "ignition_etcd" {
-  source = "github.com/getamis/terraform-ignition-etcd?ref=v1.19.16.0"
+  source = "github.com/getamis/terraform-ignition-etcd?ref=v1.19.16.2"
 
   name                  = var.name
   containers            = var.containers

--- a/modules/aws/kube-etcd/main.tf
+++ b/modules/aws/kube-etcd/main.tf
@@ -1,9 +1,10 @@
 locals {
-  vpc_id             = data.aws_subnet.etcd[0].vpc_id
-  az_num             = length(data.aws_availability_zones.available.names)
-  client_port        = 2379
-  peer_port          = 2380
-  node_exporter_port = 9100
+  vpc_id                     = data.aws_subnet.etcd[0].vpc_id
+  az_num                     = length(data.aws_availability_zones.available.names)
+  client_port                = 2379
+  peer_port                  = 2380
+  etcd_metrics_exporter_port = 2381
+  node_exporter_port         = 9100
 
   iops_by_type = {
     root = {

--- a/modules/aws/kube-etcd/sg.tf
+++ b/modules/aws/kube-etcd/sg.tf
@@ -62,3 +62,13 @@ resource "aws_security_group_rule" "ingress_node_exporter_from_worker" {
   from_port   = local.node_exporter_port
   to_port     = local.node_exporter_port
 }
+
+resource "aws_security_group_rule" "ingress_etcd_metrics_exporter_from_worker" {
+  type              = "ingress"
+  security_group_id = aws_security_group.etcd.id
+
+  protocol    = "tcp"
+  cidr_blocks = [data.aws_vpc.etcd.cidr_block]
+  from_port   = local.etcd_metrics_exporter_port
+  to_port     = local.etcd_metrics_exporter_port
+}


### PR DESCRIPTION
module: https://github.com/getamis/terraform-ignition-etcd/pull/17

Update `terraform-ignition-etcd` module version to install `etcd-metrics-proxy`, and allow worker node scrape etcd metrics

(Will tag v1.19.16.3)