### PR TITLE
FEATURE: etcd terraform module improvement

### DIFF
--- a/docs/variables/aws/elastikube.md
+++ b/docs/variables/aws/elastikube.md
@@ -53,6 +53,7 @@ This document gives an overview of variables used in the AWS platform of the ela
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_allowed_etcd_mgmt_cidr"></a> [allowed\_etcd\_mgmt\_cidr](#input\_allowed\_etcd\_mgmt\_cidr) | (Option) A list of CIDR networks to allow to manage etcd cluster. | `list(string)` | n/a | yes |
 | <a name="input_allowed_ssh_cidr"></a> [allowed\_ssh\_cidr](#input\_allowed\_ssh\_cidr) | (Optional) A list of CIDR networks to allow ssh access to. | `list(string)` | n/a | yes |
 | <a name="input_annotate_pod_ip"></a> [annotate\_pod\_ip](#input\_annotate\_pod\_ip) | (Optional) enable to fix pod startup connectivity issue on installing Calico with aws-vpc-cni plugin. (Issue: https://github.com/aws/amazon-vpc-cni-k8s/issues/493) | `bool` | `false` | no |
 | <a name="input_auth_webhook_kubeconfig_path"></a> [auth\_webhook\_kubeconfig\_path](#input\_auth\_webhook\_kubeconfig\_path) | The path of webhook kubeconfig for kube-apiserver. | `string` | `"/etc/kubernetes/config/aws-iam-authenticator/kubeconfig"` | no |

--- a/docs/variables/aws/kube-worker.md
+++ b/docs/variables/aws/kube-worker.md
@@ -19,13 +19,13 @@ This document gives an overview of variables used in the AWS platform of the kub
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_ignition_docker"></a> [ignition\_docker](#module\_ignition\_docker) | github.com/getamis/terraform-ignition-reinforcements//modules/docker | v1.23.10.0 |
+| <a name="module_ignition_docker"></a> [ignition\_docker](#module\_ignition\_docker) | github.com/getamis/terraform-ignition-reinforcements//modules/docker | v1.23.10.1 |
 | <a name="module_ignition_kubelet"></a> [ignition\_kubelet](#module\_ignition\_kubelet) | github.com/getamis/terraform-ignition-kubernetes//modules/kubelet | v1.23.10.3 |
-| <a name="module_ignition_legacy_cgroups"></a> [ignition\_legacy\_cgroups](#module\_ignition\_legacy\_cgroups) | github.com/getamis/terraform-ignition-reinforcements//modules/legacy-cgroups | v1.23.10.0 |
-| <a name="module_ignition_locksmithd"></a> [ignition\_locksmithd](#module\_ignition\_locksmithd) | github.com/getamis/terraform-ignition-reinforcements//modules/locksmithd | v1.23.10.0 |
-| <a name="module_ignition_sshd"></a> [ignition\_sshd](#module\_ignition\_sshd) | github.com/getamis/terraform-ignition-reinforcements//modules/sshd | v1.23.10.0 |
-| <a name="module_ignition_systemd_networkd"></a> [ignition\_systemd\_networkd](#module\_ignition\_systemd\_networkd) | github.com/getamis/terraform-ignition-reinforcements//modules/systemd-networkd | v1.23.10.0 |
-| <a name="module_ignition_update_ca_certificates"></a> [ignition\_update\_ca\_certificates](#module\_ignition\_update\_ca\_certificates) | github.com/getamis/terraform-ignition-reinforcements//modules/update-ca-certificates | v1.23.10.0 |
+| <a name="module_ignition_legacy_cgroups"></a> [ignition\_legacy\_cgroups](#module\_ignition\_legacy\_cgroups) | github.com/getamis/terraform-ignition-reinforcements//modules/legacy-cgroups | v1.23.10.1 |
+| <a name="module_ignition_locksmithd"></a> [ignition\_locksmithd](#module\_ignition\_locksmithd) | github.com/getamis/terraform-ignition-reinforcements//modules/locksmithd | v1.23.10.1 |
+| <a name="module_ignition_sshd"></a> [ignition\_sshd](#module\_ignition\_sshd) | github.com/getamis/terraform-ignition-reinforcements//modules/sshd | v1.23.10.1 |
+| <a name="module_ignition_systemd_networkd"></a> [ignition\_systemd\_networkd](#module\_ignition\_systemd\_networkd) | github.com/getamis/terraform-ignition-reinforcements//modules/systemd-networkd | v1.23.10.1 |
+| <a name="module_ignition_update_ca_certificates"></a> [ignition\_update\_ca\_certificates](#module\_ignition\_update\_ca\_certificates) | github.com/getamis/terraform-ignition-reinforcements//modules/update-ca-certificates | v1.23.10.1 |
 | <a name="module_lifecycle_hook"></a> [lifecycle\_hook](#module\_lifecycle\_hook) | github.com/getamis/terraform-aws-asg-lifecycle//modules/kubernetes | v1.19.16.0 |
 
 ## Resources

--- a/modules/aws/elastikube/etcd.tf
+++ b/modules/aws/elastikube/etcd.tf
@@ -1,11 +1,12 @@
 module "etcd" {
   source = "../../aws/kube-etcd"
 
-  name             = var.name
-  ssh_key          = var.ssh_key
-  allowed_ssh_cidr = var.allowed_ssh_cidr
-  instance_config  = var.etcd_instance_config
-  containers       = var.override_containers
+  name                   = var.name
+  ssh_key                = var.ssh_key
+  allowed_ssh_cidr       = var.allowed_ssh_cidr
+  allowed_etcd_mgmt_cidr = var.allowed_etcd_mgmt_cidr
+  instance_config        = var.etcd_instance_config
+  containers             = var.override_containers
 
   instance_volume_config = var.etcd_instance_volume_config
 

--- a/modules/aws/elastikube/sg-worker.tf
+++ b/modules/aws/elastikube/sg-worker.tf
@@ -77,7 +77,7 @@ resource "aws_security_group_rule" "workers_to_coredns_metrics" {
 }
 
 resource "aws_security_group_rule" "workers_ingress_ssh" {
-  count             = var.debug_mode ? 1 : 0
+  count             = (var.debug_mode && length(var.allowed_ssh_cidr) != 0) ? 1 : 0
   type              = "ingress"
   description       = "Allow access from ssh."
   security_group_id = aws_security_group.workers.id

--- a/modules/aws/elastikube/variables.tf
+++ b/modules/aws/elastikube/variables.tf
@@ -384,11 +384,13 @@ variable "ssh_key" {
 variable "allowed_ssh_cidr" {
   description = "(Optional) A list of CIDR networks to allow ssh access to."
   type        = list(string)
+  default     = []
 }
 
 variable "allowed_etcd_mgmt_cidr" {
   description = "(Option) A list of CIDR networks to allow to manage etcd cluster."
   type        = list(string)
+  default     = []
 }
 
 variable "hostzone" {

--- a/modules/aws/elastikube/variables.tf
+++ b/modules/aws/elastikube/variables.tf
@@ -386,6 +386,11 @@ variable "allowed_ssh_cidr" {
   type        = list(string)
 }
 
+variable "allowed_etcd_mgmt_cidr" {
+  description = "(Option) A list of CIDR networks to allow to manage etcd cluster."
+  type        = list(string)
+}
+
 variable "hostzone" {
   description = "(Optional) The cluster private hostname. If not specified, <cluster name>.com will be used."
   type        = string

--- a/modules/aws/kube-etcd/ignition.tf
+++ b/modules/aws/kube-etcd/ignition.tf
@@ -1,15 +1,15 @@
 module "ignition_docker" {
-  source = "github.com/getamis/terraform-ignition-reinforcements//modules/docker?ref=v1.23.10.0"
+  source = "github.com/getamis/terraform-ignition-reinforcements//modules/docker?ref=v1.23.10.1"
 }
 
 module "ignition_locksmithd" {
-  source = "github.com/getamis/terraform-ignition-reinforcements//modules/locksmithd?ref=v1.23.10.0"
+  source = "github.com/getamis/terraform-ignition-reinforcements//modules/locksmithd?ref=v1.23.10.1"
 
   reboot_strategy = var.reboot_strategy
 }
 
 module "ignition_update_ca_certificates" {
-  source = "github.com/getamis/terraform-ignition-reinforcements//modules/update-ca-certificates?ref=v1.23.10.0"
+  source = "github.com/getamis/terraform-ignition-reinforcements//modules/update-ca-certificates?ref=v1.23.10.1"
 }
 
 module "ignition_node_exporter" {
@@ -17,7 +17,7 @@ module "ignition_node_exporter" {
 }
 
 module "ignition_sshd" {
-  source = "github.com/getamis/terraform-ignition-reinforcements//modules/sshd?ref=v1.23.10.0"
+  source = "github.com/getamis/terraform-ignition-reinforcements//modules/sshd?ref=v1.23.10.1"
   enable = var.debug_mode
 }
 

--- a/modules/aws/kube-etcd/ignition.tf
+++ b/modules/aws/kube-etcd/ignition.tf
@@ -13,7 +13,7 @@ module "ignition_update_ca_certificates" {
 }
 
 module "ignition_node_exporter" {
-  source = "github.com/getamis/terraform-ignition-reinforcements//modules/node-exporter?ref=v1.23.10.0"
+  source = "github.com/getamis/terraform-ignition-reinforcements//modules/node-exporter?ref=v1.23.10.1"
 }
 
 module "ignition_sshd" {

--- a/modules/aws/kube-etcd/ignition.tf
+++ b/modules/aws/kube-etcd/ignition.tf
@@ -22,13 +22,14 @@ module "ignition_sshd" {
 }
 
 module "ignition_etcd" {
-  source = "github.com/getamis/terraform-ignition-etcd?ref=v1.23.10.0"
+  source = "github.com/getamis/terraform-ignition-etcd?ref=v1.23.10.1"
 
   name                  = var.name
   containers            = var.containers
   discovery_service_srv = local.discovery_service
   client_port           = local.client_port
   peer_port             = local.peer_port
+  proxy_port            = local.proxy_port
   device_name           = var.instance_config["data_device_rename"]
   data_path             = var.instance_config["data_path"]
   log_level             = var.debug_mode ? "debug" : "error"

--- a/modules/aws/kube-etcd/main.tf
+++ b/modules/aws/kube-etcd/main.tf
@@ -3,6 +3,7 @@ locals {
   az_num             = length(data.aws_availability_zones.available.names)
   client_port        = 2379
   peer_port          = 2380
+  proxy_port         = 2381
   node_exporter_port = 9100
 
   iops_by_type = {

--- a/modules/aws/kube-etcd/outputs.tf
+++ b/modules/aws/kube-etcd/outputs.tf
@@ -1,7 +1,7 @@
 output "endpoints" {
   value = [
-    for instance_ip in aws_instance.etcd.*.private_ip :
-    "https://ip-${replace(instance_ip, ".", "-")}.${local.discovery_service}:${local.client_port}"
+    for etcd_ip in aws_network_interface.etcd.*.private_ips[0] :
+    "https://ip-${replace(etcd_ip, ".", "-")}.${local.discovery_service}:${local.client_port}"
   ]
 }
 

--- a/modules/aws/kube-etcd/sg.tf
+++ b/modules/aws/kube-etcd/sg.tf
@@ -43,7 +43,7 @@ resource "aws_security_group_rule" "etcd_ingress_from_master" {
 }
 
 resource "aws_security_group_rule" "etcd_ssh" {
-  count             = var.debug_mode ? 1 : 0
+  count             = (var.debug_mode && length(var.allowed_ssh_cidr) != 0) ? 1 : 0
   type              = "ingress"
   security_group_id = aws_security_group.etcd.id
 
@@ -54,6 +54,7 @@ resource "aws_security_group_rule" "etcd_ssh" {
 }
 
 resource "aws_security_group_rule" "etcd_management" {
+  count             = length(var.allowed_etcd_mgmt_cidr) != 0 ? 1 : 0
   type              = "ingress"
   security_group_id = aws_security_group.etcd.id
 

--- a/modules/aws/kube-etcd/sg.tf
+++ b/modules/aws/kube-etcd/sg.tf
@@ -72,3 +72,13 @@ resource "aws_security_group_rule" "ingress_node_exporter_from_worker" {
   from_port   = local.node_exporter_port
   to_port     = local.node_exporter_port
 }
+
+resource "aws_security_group_rule" "ingress_etcd_metrics_exporter_from_worker" {
+  type              = "ingress"
+  security_group_id = aws_security_group.etcd.id
+
+  protocol    = "tcp"
+  cidr_blocks = [data.aws_vpc.etcd.cidr_block]
+  from_port   = local.proxy_port
+  to_port     = local.proxy_port
+}

--- a/modules/aws/kube-etcd/sg.tf
+++ b/modules/aws/kube-etcd/sg.tf
@@ -53,6 +53,16 @@ resource "aws_security_group_rule" "etcd_ssh" {
   to_port     = 22
 }
 
+resource "aws_security_group_rule" "etcd_management" {
+  type              = "ingress"
+  security_group_id = aws_security_group.etcd.id
+
+  protocol    = "tcp"
+  cidr_blocks = var.allowed_etcd_mgmt_cidr
+  from_port   = local.client_port
+  to_port     = local.client_port
+}
+
 resource "aws_security_group_rule" "ingress_node_exporter_from_worker" {
   type              = "ingress"
   security_group_id = aws_security_group.etcd.id

--- a/modules/aws/kube-etcd/variables.tf
+++ b/modules/aws/kube-etcd/variables.tf
@@ -147,6 +147,11 @@ variable "allowed_ssh_cidr" {
   type        = list(string)
 }
 
+variable "allowed_etcd_mgmt_cidr" {
+  description = "(Option) A list of CIDR networks to allow to manage etcd cluster."
+  type        = list(string)
+}
+
 variable "s3_bucket" {
   description = <<EOF
     (Optional) Unique name under which the Amazon S3 bucket will be created. Bucket name must start with a lower case name and is limited to 63 characters.

--- a/modules/aws/kube-etcd/variables.tf
+++ b/modules/aws/kube-etcd/variables.tf
@@ -145,11 +145,13 @@ variable "ssh_key" {
 variable "allowed_ssh_cidr" {
   description = "(Optional) A list of CIDR networks to allow ssh access to."
   type        = list(string)
+  default     = []
 }
 
 variable "allowed_etcd_mgmt_cidr" {
   description = "(Option) A list of CIDR networks to allow to manage etcd cluster."
   type        = list(string)
+  default     = []
 }
 
 variable "s3_bucket" {

--- a/modules/aws/kube-master/ignition.tf
+++ b/modules/aws/kube-master/ignition.tf
@@ -95,32 +95,32 @@ module "ignition_kubernetes" {
 }
 
 module "ignition_docker" {
-  source = "github.com/getamis/terraform-ignition-reinforcements//modules/docker?ref=v1.23.10.0"
+  source = "github.com/getamis/terraform-ignition-reinforcements//modules/docker?ref=v1.23.10.1"
 }
 
 module "ignition_locksmithd" {
-  source          = "github.com/getamis/terraform-ignition-reinforcements//modules/locksmithd?ref=v1.23.10.0"
+  source          = "github.com/getamis/terraform-ignition-reinforcements//modules/locksmithd?ref=v1.23.10.1"
   reboot_strategy = var.reboot_strategy
 }
 
 module "ignition_update_ca_certificates" {
-  source = "github.com/getamis/terraform-ignition-reinforcements//modules/update-ca-certificates?ref=v1.23.10.0"
+  source = "github.com/getamis/terraform-ignition-reinforcements//modules/update-ca-certificates?ref=v1.23.10.1"
 }
 
 module "ignition_sshd" {
-  source = "github.com/getamis/terraform-ignition-reinforcements//modules/sshd?ref=v1.23.10.0"
+  source = "github.com/getamis/terraform-ignition-reinforcements//modules/sshd?ref=v1.23.10.1"
 
   enable = var.debug_mode
 }
 
 module "ignition_systemd_networkd" {
-  source = "github.com/getamis/terraform-ignition-reinforcements//modules/systemd-networkd?ref=v1.23.10.0"
+  source = "github.com/getamis/terraform-ignition-reinforcements//modules/systemd-networkd?ref=v1.23.10.1"
 
   debug = var.debug_mode
 }
 
 module "ignition_legacy_cgroups" {
-  source = "github.com/getamis/terraform-ignition-reinforcements//modules/legacy-cgroups?ref=v1.23.10.0"
+  source = "github.com/getamis/terraform-ignition-reinforcements//modules/legacy-cgroups?ref=v1.23.10.1"
 }
 
 data "ignition_config" "main" {

--- a/modules/aws/kube-master/main.tf
+++ b/modules/aws/kube-master/main.tf
@@ -111,11 +111,6 @@ resource "aws_launch_template" "master" {
 
   lifecycle {
     create_before_destroy = true
-
-    # Ignore changes in the AMI which force recreation of the resource. This
-    # avoids accidental deletion of nodes whenever a new CoreOS Release comes
-    # out.
-    ignore_changes = [image_id]
   }
 }
 

--- a/modules/aws/kube-master/sg.tf
+++ b/modules/aws/kube-master/sg.tf
@@ -90,8 +90,7 @@ resource "aws_security_group_rule" "master_ingress_from_lb" {
 }
 
 resource "aws_security_group_rule" "master_ssh" {
-  count = var.debug_mode ? 1 : 0
-
+  count             = (var.debug_mode && length(var.allowed_ssh_cidr) != 0) ? 1 : 0
   type              = "ingress"
   security_group_id = local.master_sg_id
 

--- a/modules/aws/kube-master/variables.tf
+++ b/modules/aws/kube-master/variables.tf
@@ -308,6 +308,7 @@ variable "ssh_key" {
 variable "allowed_ssh_cidr" {
   description = "(Optional) A list of CIDR networks to allow ssh access to."
   type        = list(string)
+  default     = []
 }
 
 variable "s3_bucket" {

--- a/modules/aws/kube-worker/ignition.tf
+++ b/modules/aws/kube-worker/ignition.tf
@@ -8,33 +8,33 @@ locals {
 }
 
 module "ignition_docker" {
-  source = "github.com/getamis/terraform-ignition-reinforcements//modules/docker?ref=v1.23.10.0"
+  source = "github.com/getamis/terraform-ignition-reinforcements//modules/docker?ref=v1.23.10.1"
 }
 
 module "ignition_locksmithd" {
-  source = "github.com/getamis/terraform-ignition-reinforcements//modules/locksmithd?ref=v1.23.10.0"
+  source = "github.com/getamis/terraform-ignition-reinforcements//modules/locksmithd?ref=v1.23.10.1"
 
   reboot_strategy = var.reboot_strategy
 }
 
 module "ignition_update_ca_certificates" {
-  source = "github.com/getamis/terraform-ignition-reinforcements//modules/update-ca-certificates?ref=v1.23.10.0"
+  source = "github.com/getamis/terraform-ignition-reinforcements//modules/update-ca-certificates?ref=v1.23.10.1"
 }
 
 module "ignition_sshd" {
-  source = "github.com/getamis/terraform-ignition-reinforcements//modules/sshd?ref=v1.23.10.0"
+  source = "github.com/getamis/terraform-ignition-reinforcements//modules/sshd?ref=v1.23.10.1"
 
   enable = var.debug_mode
 }
 
 module "ignition_systemd_networkd" {
-  source = "github.com/getamis/terraform-ignition-reinforcements//modules/systemd-networkd?ref=v1.23.10.0"
+  source = "github.com/getamis/terraform-ignition-reinforcements//modules/systemd-networkd?ref=v1.23.10.1"
 
   debug = var.debug_mode
 }
 
 module "ignition_legacy_cgroups" {
-  source = "github.com/getamis/terraform-ignition-reinforcements//modules/legacy-cgroups?ref=v1.23.10.0"
+  source = "github.com/getamis/terraform-ignition-reinforcements//modules/legacy-cgroups?ref=v1.23.10.1"
 }
 
 data "aws_s3_object" "bootstrapping_kubeconfig" {

--- a/modules/aws/kube-worker/main.tf
+++ b/modules/aws/kube-worker/main.tf
@@ -149,11 +149,6 @@ resource "aws_launch_template" "worker" {
 
   lifecycle {
     create_before_destroy = true
-
-    # Ignore changes in the AMI which force recreation of the resource. This
-    # avoids accidental deletion of nodes whenever a new CoreOS Release comes
-    # out.
-    ignore_changes = [image_id]
   }
 }
 


### PR DESCRIPTION
- Remove `image_id` changes ignoring of master, worker and etcd nodes
- Add new security group rule to allow specific CIDR accessing etcd cluster
- Support etcd-metrics-proxy service (Ref: https://github.com/getamis/terraform-ignition-etcd/pull/18)
- Update node-exporter to v1.5.0 and Enable ethtool collector (For etcd nodes) (Ref: https://github.com/getamis/terraform-ignition-reinforcements/pull/15)
- Be able to update etcd instances directly, no need to terminate instance before terraform apply
  - https://github.com/getamis/terraform-ignition-etcd/pull/19