### PR TITLE
FIX: aws_s3_object limitation of only supporting up to 10 tags

### DIFF
--- a/modules/aws/irsa/main.tf
+++ b/modules/aws/irsa/main.tf
@@ -65,8 +65,9 @@ resource "aws_s3_bucket" "oidc" {
   bucket = var.oidc_s3_bucket
 
   tags = merge(
+    var.extra_tags,
     { "Name" = "${var.name}-oidc-${md5("${var.name}-oidc")}" },
-  var.extra_tags)
+  )
 }
 
 resource "aws_s3_bucket_acl" "oidc" {
@@ -85,10 +86,10 @@ resource "aws_s3_object" "discovery_json" {
     issuer_host = "https://${local.odic_servername}/${var.oidc_s3_bucket}"
   })
 
-  tags = merge({
+  tags = {
     "Name" = "discovery.json"
     "Role" = "k8s-master"
-  }, var.extra_tags)
+  }
 }
 
 data "local_file" "keys_json" {
@@ -106,8 +107,8 @@ resource "aws_s3_object" "keys_json" {
   acl          = "public-read"
   content_type = "application/json"
 
-  tags = merge({
+  tags = {
     "Name" = "keys.json"
     "Role" = "k8s-master"
-  }, var.extra_tags)
+  }
 }

--- a/modules/aws/kube-etcd/ignition.tf
+++ b/modules/aws/kube-etcd/ignition.tf
@@ -89,11 +89,11 @@ resource "aws_s3_object" "ignition" {
 
   server_side_encryption = "AES256"
 
-  tags = merge(var.extra_tags, {
+  tags = {
     "Name"                              = "ign-etcd-${var.name}.json"
     "Role"                              = "etcd"
     "kubernetes.io/cluster/${var.name}" = "owned"
-  })
+  }
 }
 
 

--- a/modules/aws/kube-master/ignition.tf
+++ b/modules/aws/kube-master/ignition.tf
@@ -167,11 +167,11 @@ resource "aws_s3_object" "admin_kubeconfig" {
   server_side_encryption = "AES256"
   content_type           = "text/plain"
 
-  tags = merge(var.extra_tags, {
+  tags = {
     "Name"                              = "admin.conf"
     "Role"                              = "k8s-master"
     "kubernetes.io/cluster/${var.name}" = "owned"
-  })
+  }
 }
 
 // TODO: use AWS Secrets Manager to store this, or encryption by KMS.
@@ -184,11 +184,11 @@ resource "aws_s3_object" "bootstrapping_kubeconfig" {
   server_side_encryption = "AES256"
   content_type           = "text/plain"
 
-  tags = merge(var.extra_tags, {
+  tags = {
     "Name"                              = "bootstrap-kubelet.conf"
     "Role"                              = "k8s-master"
     "kubernetes.io/cluster/${var.name}" = "owned"
-  })
+  }
 }
 
 resource "aws_s3_object" "ignition" {
@@ -198,11 +198,11 @@ resource "aws_s3_object" "ignition" {
 
   server_side_encryption = "AES256"
 
-  tags = merge(var.extra_tags, {
+  tags = {
     "Name"                              = "ign-master-${var.name}.json"
     "Role"                              = "k8s-master"
     "kubernetes.io/cluster/${var.name}" = "owned"
-  })
+  }
 }
 
 data "ignition_config" "s3" {

--- a/modules/aws/kube-worker/ignition.tf
+++ b/modules/aws/kube-worker/ignition.tf
@@ -106,11 +106,11 @@ resource "aws_s3_object" "ignition" {
 
   server_side_encryption = "AES256"
 
-  tags = merge(var.extra_tags, {
+  tags = {
     "Name"                              = "ign-worker-${var.instance_config["name"]}.json"
     "Role"                              = "k8s-worker"
     "kubernetes.io/cluster/${var.name}" = "owned"
-  })
+  }
 }
 
 data "ignition_config" "s3" {


### PR DESCRIPTION
- remove extra_tags from aws_s3_object to prevent tag override and avoid exceeding the limitation.