### PR TITLE
FIX: apply etcd secutiry group to etcd instance default eni

### DIFF
--- a/modules/aws/kube-etcd/main.tf
+++ b/modules/aws/kube-etcd/main.tf
@@ -92,6 +92,11 @@ resource "aws_instance" "etcd" {
   key_name             = var.debug_mode ? var.ssh_key : ""
   iam_instance_profile = aws_iam_instance_profile.etcd.id
 
+  vpc_security_group_ids = compact(concat(
+    var.security_group_ids,
+    [aws_security_group.etcd.id]
+  ))
+
   user_data                   = data.ignition_config.s3.rendered
   user_data_replace_on_change = true
 


### PR DESCRIPTION
The etcd security group should be applied not only to the extra ENI but also to the EC2's default ENI.