### PR TITLE
FEATURE: exclude terminating node from alb target

### DIFF
--- a/modules/aws/kube-master/main.tf
+++ b/modules/aws/kube-master/main.tf
@@ -122,7 +122,7 @@ resource "aws_launch_template" "master" {
 
 module "lifecycle_hook" {
   count  = var.enable_asg_life_cycle ? 1 : 0
-  source = "git::ssh://git@github.com/getamis/terraform-aws-asg-lifecycle//modules/kubernetes?ref=v1.27.4.0"
+  source = "git::ssh://git@github.com/getamis/terraform-aws-asg-lifecycle//modules/kubernetes?ref=v1.27.4.1"
 
   name                           = "${var.name}-master"
   cluster_name                   = var.name

--- a/modules/aws/kube-worker/main.tf
+++ b/modules/aws/kube-worker/main.tf
@@ -159,7 +159,7 @@ resource "aws_launch_template" "worker" {
 
 module "lifecycle_hook" {
   count  = var.enable_asg_life_cycle ? 1 : 0
-  source = "git::ssh://git@github.com/getamis/terraform-aws-asg-lifecycle//modules/kubernetes?ref=v1.27.4.0"
+  source = "git::ssh://git@github.com/getamis/terraform-aws-asg-lifecycle//modules/kubernetes?ref=v1.27.4.1"
 
   name                           = "${var.name}-worker-${var.instance_config["name"]}"
   cluster_name                   = var.name


### PR DESCRIPTION
https://github.com/getamis/terraform-aws-asg-lifecycle/pull/5
To prevent 502/504 errors when worker node is terminating, remove the node from the ALB target group before termination.