### PR TITLE
FEATURE: Update module sources and add IP allocation strategy for AWS VPC CNI

### DIFF
--- a/modules/aws/iam-authenticator/main.tf
+++ b/modules/aws/iam-authenticator/main.tf
@@ -1,5 +1,5 @@
 module "ignition_iam_auth" {
-  source = "github.com/getamis/terraform-ignition-kubernetes//modules/extra-addons/aws-iam-authenticator?ref=v1.31.1.1"
+  source = "github.com/getamis/terraform-ignition-kubernetes//modules/extra-addons/aws-iam-authenticator?ref=feat%2Faws-vpc-cni-ip-allocation-strategy"
 
   cluster_name        = var.name
   container           = var.container

--- a/modules/aws/irsa/main.tf
+++ b/modules/aws/irsa/main.tf
@@ -12,7 +12,7 @@ locals {
 data "aws_region" "current" {}
 
 module "ignition_pod_idenity_webhook" {
-  source = "github.com/getamis/terraform-ignition-kubernetes//modules/extra-addons/aws-pod-identity-webhook?ref=v1.31.1.1"
+  source = "github.com/getamis/terraform-ignition-kubernetes//modules/extra-addons/aws-pod-identity-webhook?ref=feat%2Faws-vpc-cni-ip-allocation-strategy"
 
   container                  = var.container
   service_name               = var.service_name

--- a/modules/aws/kube-master/ignition.tf
+++ b/modules/aws/kube-master/ignition.tf
@@ -12,7 +12,7 @@ resource "random_password" "encryption_secret" {
 }
 
 module "ignition_kubernetes" {
-  source                = "github.com/getamis/terraform-ignition-kubernetes//?ref=v1.31.1.1"
+  source                = "github.com/getamis/terraform-ignition-kubernetes//?ref=feat%2Faws-vpc-cni-ip-allocation-strategy"
   binaries              = var.binaries
   containers            = var.containers
   kubernetes_version    = var.kubernetes_version
@@ -58,6 +58,7 @@ module "ignition_kubernetes" {
   external_snat            = var.external_snat
   enable_network_policy    = var.enable_network_policy
   max_pods                 = var.max_pods
+  ip_allocation_strategy   = var.ip_allocation_strategy
   log_level                = var.log_level
 
   certs = {

--- a/modules/aws/kube-master/variables.tf
+++ b/modules/aws/kube-master/variables.tf
@@ -385,3 +385,23 @@ variable "log_level" {
     systemd_networkd             = "warning" # emerg, alert, crit, err, warning, notice, info, debug
   }
 }
+
+
+variable "ip_allocation_strategy" {
+  description = "The IP allocation strategy of AWS VPC CNI, Ref: https://github.com/aws/amazon-vpc-cni-k8s/blob/master/README.md"
+  type        = object({
+    warm_eni_target = optional(string, null)
+    warm_prefix_target = optional(string, null)
+    warm_ip_target = optional(string, null)
+    minimum_ip_target = optional(string, null)
+  })
+  # When enable_eni_prefix is true, prefer to use warm_ip_target and minimum_ip_target to allocate IP addresses
+  # It can prevent the CNI from keeping an entire excess prefix attached to the node.
+  # Ref: https://docs.aws.amazon.com/eks/latest/best-practices/prefix-mode-linux.html
+  default     = {
+    warm_eni_target = null
+    warm_prefix_target = null
+    warm_ip_target = "3"
+    minimum_ip_target = "5"
+  }
+}

--- a/modules/aws/kube-worker/ignition.tf
+++ b/modules/aws/kube-worker/ignition.tf
@@ -52,7 +52,7 @@ data "aws_s3_object" "bootstrapping_kubeconfig" {
 }
 
 module "ignition_kubelet" {
-  source = "github.com/getamis/terraform-ignition-kubernetes//modules/kubelet?ref=v1.31.1.1"
+  source = "github.com/getamis/terraform-ignition-kubernetes//modules/kubelet?ref=feat%2Faws-vpc-cni-ip-allocation-strategy"
 
   binaries             = var.binaries
   containers           = var.containers


### PR DESCRIPTION
- Updated module sources for aws-iam-authenticator, aws-pod-identity-webhook, kubelet, and ignition_kubernetes to reference the new feature branch.
- Introduced a new variable `ip_allocation_strategy` in kube-master to configure AWS VPC CNI IP allocation settings.